### PR TITLE
Add installation guide to README #29

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # OTP Data Entry
 Application to allow users to enter data into the Nazareth Open Tourism Platform database
+
+Find the link for the Data Entry website
+ [here](https://data-entry-fac.herokuapp.com/)
+### Endpoints
+  + `/:lang/places`
+
+### Local Installation Guide
+
++ `git clone https://github.com/foundersandcoders/OTP-Data-Entry.git`
+<br>
+
++ `npm i`
+<br>
+
++ `npm run dev`
+
+### File Structure
+```
+public/
+    reset.css
+    style.css
+src/
+    constants/
+        urls.json
+    controllers
+        home.js
+        places.js
+        router.js
+    app.js
+    start.js
+    text.js
+    views/
+        layouts/
+            main.hbs
+        home.hbs
+        places.hbs
+```


### PR DESCRIPTION
Updated the README with a local installation guide and a file structure, with possible endpoints (only `/:lang/places` for now. `/:lang/place/:id` needs to be added after the Get Specific Place pull request gets merged)