### PR TITLE
adds the status of the content if it's verified or not

### DIFF
--- a/views/events.hbs
+++ b/views/events.hbs
@@ -33,7 +33,7 @@
   <div class="pa2 dtc w4 v-mid">
     <a href="/{{../lang}}/edit-event/{{_id}}" class="f6 w4 tc grow no-underline br-pill ba bw1 ph4 pv2 mb2 dib mid-gray b gray">{{../localText.edit}}</a>
     <a href="/{{../lang}}/delete-event/{{_id}}" class="f6 w4 tc grow no-underline br-pill ba bw1 ph4 pv2 mb2 dib mid-gray b gray">{{../localText.delete}}</a>
-    <div class="f6 w4 tc grow no-underline br-pill ba bw1 ph4 pv2 {{#if this.verified}} green {{else}} red {{/if}} mb2 dib b"> Verified</div>
+    <div class="f6 w4 tc grow no-underline br-pill ba bw1 ph4 pv2 {{#if this.verified}} green {{else}} red {{/if}} mb2 dib b"> Verified {{#if this.verified}}✔️{{else}}✖️{{/if}}</div>
   </div>
 </li>
   {{/each}}

--- a/views/events.hbs
+++ b/views/events.hbs
@@ -33,6 +33,7 @@
   <div class="pa2 dtc w4 v-mid">
     <a href="/{{../lang}}/edit-event/{{_id}}" class="f6 w4 tc grow no-underline br-pill ba bw1 ph4 pv2 mb2 dib mid-gray b gray">{{../localText.edit}}</a>
     <a href="/{{../lang}}/delete-event/{{_id}}" class="f6 w4 tc grow no-underline br-pill ba bw1 ph4 pv2 mb2 dib mid-gray b gray">{{../localText.delete}}</a>
+    <div class="f6 w4 tc grow no-underline br-pill ba bw1 ph4 pv2 {{#if this.verified}} green {{else}} red {{/if}} mb2 dib b"> Verified</div>
   </div>
 </li>
   {{/each}}

--- a/views/places.hbs
+++ b/views/places.hbs
@@ -30,9 +30,11 @@
       <span class="f5 db black-70">{{this.categories}}</span>
     </div>
   </a>
-  <div class="pa2 dtc w4 v-mid">
+  <div class="pa2 dtc w4">
     <a href="/{{../lang}}/edit-place/{{_id}}" class="f6 w4 tc grow no-underline br-pill ba bw1 ph4 pv2 mb2 dib mid-gray b gray">{{../localText.edit}}</a>
     <a href="/{{../lang}}/delete-place/{{_id}}" class="f6 w4 tc grow no-underline br-pill ba bw1 ph4 pv2 mb2 dib mid-gray b gray">{{../localText.delete}}</a>
+    <a href="#" class="f6 w4 tc grow no-underline br-pill ba bw1 ph3 pv2 {{#if this.verified}} green {{else}} red {{/if}} mb2 dib b"> Verified {{#if this.verified}}✔️{{else}}✖️{{/if}}</a>
+
   </div>
 </li>
   {{/each}}


### PR DESCRIPTION
rel #104

we will start implementing the actual functionality when https://github.com/foundersandcoders/open-tourism-platform/pull/180 gets merged, cause later on this a tag that was added in this PR would let only ADMIN and SUPER accounts to verify the specific content ( maybe only show this a tag to only these specific users ? )
this is how it currently looks like :
![green](https://user-images.githubusercontent.com/24195641/36900915-cf3563b2-1e2d-11e8-960f-82aba2cff2c6.png)
![red](https://user-images.githubusercontent.com/24195641/36900921-d5e64eb0-1e2d-11e8-9f72-b1b8f3b2c422.png)
